### PR TITLE
rustdoc: prefer output from stderr on test panic

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -244,7 +244,11 @@ fn runtest(test: &str, cratename: &str, libs: SearchPaths,
                 panic!("test executable succeeded when it should have failed");
             } else if !should_panic && !out.status.success() {
                 panic!("test executable failed:\n{:?}",
-                      str::from_utf8(&out.stdout));
+                       str::from_utf8(if out.stderr.len() > 0 { 
+                                          &out.stderr
+                                      } else {
+                                          &out.stdout
+                                      }).unwrap_or(""));
             }
         }
     }


### PR DESCRIPTION
Currently if a rustdoc test panics then the fatal error message is not forwarded to the user. This change will have the test runner prefer forwarding anything on the stderr of the test process.
